### PR TITLE
feat(gcp): update watkins release

### DIFF
--- a/gcp_example/config.yaml.example
+++ b/gcp_example/config.yaml.example
@@ -3,6 +3,7 @@ project: "daytona-test"
 
 # Name of the GKE cluster
 cluster_name: "daytona-workspaces"
+cluster_version: "1.29"
 
 # DNS zone that will be created in Cloud DNS.
 dns_zone: "daytona.changeme"
@@ -26,6 +27,16 @@ gke_network:
 #   admin1: 198.198.8.1/32
 #   office2: 198.199.8.1/24
 authorized_networks: {}
+
+gpu:
+  # Use GPU node pool in the cluster
+  enabled: false
+  zones: ["us-east1-c", "us-east1-d"]
+  node_type: n1-standard-16
+  # Required gpu type out of these: nvidia-tesla-k80, nvidia-tesla-p100, nvidia-tesla-p4, nvidia-tesla-v100, nvidia-tesla-t4, nvidia-tesla-a100, nvidia-a100-80gb, nvidia-l4
+  type: nvidia-tesla-t4
+  # number of GPUs per node
+  count: 4
 
 # You must replace this email address with your own.
 # Let's Encrypt will use this to contact you about expiring

--- a/gcp_example/tf-1-gke/main.tf
+++ b/gcp_example/tf-1-gke/main.tf
@@ -32,10 +32,19 @@ locals {
   region               = local.config.region
   zones                = local.config.zones
   cluster_name         = local.config.cluster_name
+  cluster_version      = local.config.cluster_version
   gke_region_subnet    = local.config.gke_network.region_subnet
   gke_service_subnet   = local.config.gke_network.service_subnet
   gke_pod_subnet       = local.config.gke_network.pod_subnet
   control_plane_subnet = local.config.gke_network.control_plane_subnet
   dns_zone             = local.config.dns_zone
   authorized_networks  = local.config.authorized_networks
+
+  gpu = {
+    enabled   = local.config.gpu.enabled
+    node_type = local.config.gpu.node_type
+    type      = local.config.gpu.type
+    count     = local.config.gpu.count
+    zones     = local.config.gpu.zones
+  }
 }

--- a/gcp_example/tf-2-k8s/cert-manager.tf
+++ b/gcp_example/tf-2-k8s/cert-manager.tf
@@ -2,7 +2,7 @@ resource "helm_release" "cert_manager" {
   name       = "cert-manager"
   repository = "https://charts.jetstack.io"
   chart      = "cert-manager"
-  version    = "1.13.2"
+  version    = "v1.13.2"
   namespace  = kubernetes_namespace.infrastructure.metadata[0].name
   atomic     = true
 
@@ -29,7 +29,8 @@ YAML
 
 module "cert_manager_service_account" {
   source              = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
-  name                = "cert-manager"
+  name                = "cert-manager-${local.cluster_name}"
+  k8s_sa_name         = "cert-manager"
   namespace           = kubernetes_namespace.infrastructure.metadata[0].name
   use_existing_k8s_sa = true
   annotate_k8s_sa     = false

--- a/gcp_example/tf-2-k8s/external-dns.tf
+++ b/gcp_example/tf-2-k8s/external-dns.tf
@@ -25,7 +25,8 @@ YAML
 
 module "external_dns_service_account" {
   source                          = "terraform-google-modules/kubernetes-engine/google//modules/workload-identity"
-  name                            = "external-dns"
+  name                            = "external-dns-${local.cluster_name}"
+  k8s_sa_name                     = "external-dns"
   namespace                       = kubernetes_namespace.infrastructure.metadata[0].name
   use_existing_k8s_sa             = true
   annotate_k8s_sa                 = false

--- a/gcp_example/tf-2-k8s/longhorn.tf
+++ b/gcp_example/tf-2-k8s/longhorn.tf
@@ -71,18 +71,6 @@ YAML
 
 }
 
-resource "kubectl_manifest" "longhorn_priority_class" {
-  yaml_body = <<YAML
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: custom-node-critical
-value: 1000000000
-globalDefault: false
-description: "Custom PriorityClass for longhorn pods"
-YAML
-}
-
 resource "kubectl_manifest" "longhorn_iscsi" {
   yaml_body = <<YAML
 apiVersion: apps/v1
@@ -143,7 +131,7 @@ resource "helm_release" "longhorn" {
   name       = "longhorn"
   repository = "https://charts.longhorn.io"
   chart      = "longhorn"
-  version    = "1.5.4"
+  version    = "1.6.2"
   namespace  = kubernetes_namespace.longhorn-system.metadata[0].name
   timeout    = 300
   atomic     = true
@@ -168,10 +156,8 @@ defaultSettings:
   storageReservedPercentageForDefaultDisk: 15
   systemManagedComponentsNodeSelector: "daytona.io/runtime-ready:true"
   taintToleration: "daytona.io/node-role=storage:NoSchedule;daytona.io/node-role=workload:NoSchedule"
-  priorityClass: custom-node-critical
   guaranteedInstanceManagerCPU: 20
 longhornManager:
-  priorityClass: custom-node-critical
   nodeSelector:
     daytona.io/runtime-ready: "true"
   tolerations:
@@ -184,7 +170,6 @@ longhornManager:
       value: "workload"
       effect: "NoSchedule"
 longhornDriver:
-  priorityClass: custom-node-critical
   nodeSelector:
     daytona.io/runtime-ready: "true"
   tolerations:
@@ -202,7 +187,6 @@ longhornDriver:
   depends_on = [
     kubectl_manifest.gke_raid_disks,
     kubectl_manifest.longhorn_iscsi,
-    kubectl_manifest.longhorn_priority_class,
     kubectl_manifest.sysbox,
     kubectl_manifest.runtime_checker
   ]

--- a/gcp_example/tf-2-k8s/namespace.tf
+++ b/gcp_example/tf-2-k8s/namespace.tf
@@ -25,3 +25,11 @@ resource "kubernetes_namespace" "watkins" {
     name = "watkins"
   }
 }
+
+resource "kubernetes_namespace" "gpu-operator" {
+  count = local.gpu.enabled ? 1 : 0
+
+  metadata {
+    name = "gpu-operator"
+  }
+}

--- a/gcp_example/tf-2-k8s/nvidia-gpu-operator.tf
+++ b/gcp_example/tf-2-k8s/nvidia-gpu-operator.tf
@@ -1,0 +1,48 @@
+resource "kubectl_manifest" "gpu_resource_quota" {
+  count     = local.gpu.enabled ? 1 : 0
+  yaml_body = <<YAML
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: gpu-operator-quota
+  namespace: ${kubernetes_namespace.gpu-operator[0].metadata[0].name}
+spec:
+  hard:
+    pods: 100
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+        - system-node-critical
+        - system-cluster-critical
+YAML
+
+}
+
+resource "helm_release" "gpu_operator" {
+  count                      = local.gpu.enabled ? 1 : 0
+  name                       = "gpu-operator"
+  repository                 = "https://helm.ngc.nvidia.com/nvidia"
+  chart                      = "gpu-operator"
+  version                    = "v24.3.0"
+  create_namespace           = false
+  namespace                  = kubernetes_namespace.gpu-operator[0].metadata[0].name
+  timeout                    = 300
+  atomic                     = true
+  wait                       = true
+  disable_openapi_validation = true
+
+  values = [<<YAML
+operator:
+  defaultRuntime: containerd
+  upgradeCRD: true
+toolkit:
+  env:
+  - name: CONTAINERD_RUNTIME_CLASS
+    value: nvidia
+  - name: CONTAINERD_SET_AS_DEFAULT
+    value: "false"
+YAML
+  ]
+}

--- a/gcp_example/tf-2-k8s/outputs.tf
+++ b/gcp_example/tf-2-k8s/outputs.tf
@@ -1,0 +1,21 @@
+output "daytona_access_instructions" {
+  value = <<EOT
+** Please be patient while the Daytona is being deployed, DNS records propagate and ingress is ready **
+
+1. Daytona can be accessed through the following DNS name:
+
+   https://${local.dns_zone}
+
+2. To access the Administration Console use the following:
+
+   URL:       https://admin.${local.dns_zone}
+   Username:  admin
+   Password:  $(kubectl get secret --namespace ${kubernetes_namespace.watkins.metadata[0].name} ${helm_release.daytona_workspace.name} -o jsonpath={.data.admin-password} | base64 --decode; echo)
+
+3. To access Keycloak admin portal use the following:
+
+   URL:       https://id.${local.dns_zone}
+   Username:  admin
+   Password:  $(kubectl get secret --namespace ${kubernetes_namespace.watkins.metadata[0].name} ${helm_release.daytona_workspace.name}-watkins-keycloak -o jsonpath={.data.admin-password} | base64 --decode; echo)
+EOT
+}

--- a/gcp_example/tf-2-k8s/sysbox.tf
+++ b/gcp_example/tf-2-k8s/sysbox.tf
@@ -69,7 +69,7 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: sysbox-deploy-k8s
-        image: registry.nestybox.com/nestybox/sysbox-deploy-k8s:v0.6.2
+        image: registry.nestybox.com/nestybox/sysbox-deploy-k8s:v0.6.4
         imagePullPolicy: Always
         command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh ce install" ]
         env:
@@ -175,9 +175,6 @@ kind: RuntimeClass
 metadata:
   name: sysbox-runc
 handler: sysbox-runc
-scheduling:
-  nodeSelector:
-    sysbox-runtime: running
 YAML
 
   depends_on = [kubectl_manifest.sysbox]


### PR DESCRIPTION
* allow separation of longhorn components only on workload and longhorn volume nodes
* add GPU support (setting to enable is in the config.yaml)
* update longhorn and sysbox release
* set k8s version to 1.29
* add TF output with access information to admin dashboard so licence can be added
* allow scale down of workload pool to 0 (this will require longer initial watkins install as prepull of longhorn image will trigger scale up in order to finish)