### PR TITLE
feat(aws): update watkins release

### DIFF
--- a/aws_example/tf-1-eks/eks.tf
+++ b/aws_example/tf-1-eks/eks.tf
@@ -128,12 +128,6 @@ module "eks" {
           yum install amazon-ssm-agent -y
           systemctl enable amazon-ssm-agent
           systemctl start amazon-ssm-agent
-
-          yum --setopt=tsflags=noscripts install iscsi-initiator-utils -y
-          echo "InitiatorName=$(/sbin/iscsi-iname)" > /etc/iscsi/initiatorname.iscsi
-          systemctl enable iscsid
-          systemctl start iscsid
-          modprobe iscsi_tcp
           EOF
       block_device_mappings = {
         xvda = {
@@ -147,8 +141,7 @@ module "eks" {
         }
       }
       labels = {
-        "daytona.io/node-role"     = "app"
-        "daytona.io/runtime-ready" = "true"
+        "daytona.io/node-role" = "app"
       }
     },
 
@@ -248,8 +241,8 @@ module "eks" {
         }
       )
       capacity_type              = "ON_DEMAND"
-      desired_size               = 1
-      min_size                   = 1
+      desired_size               = 0
+      min_size                   = 0
       max_size                   = 20
       instance_types             = ["c6a.4xlarge"]
       enable_monitoring          = true

--- a/aws_example/tf-2-k8s/cluster-autoscaler.tf
+++ b/aws_example/tf-2-k8s/cluster-autoscaler.tf
@@ -2,7 +2,7 @@ resource "helm_release" "cluster-autoscaler" {
   name       = "cluster-autoscaler"
   repository = "https://kubernetes.github.io/autoscaler"
   chart      = "cluster-autoscaler"
-  version    = "9.35.0"
+  version    = "9.37.0"
   namespace  = kubernetes_namespace.infrastructure.metadata[0].name
   atomic     = true
 
@@ -11,7 +11,7 @@ autoDiscovery:
   clusterName: ${local.cluster_name}
 image:
   repository: registry.k8s.io/autoscaling/cluster-autoscaler
-  tag: v1.28.2
+  tag: v1.29.3
 rbac:
   serviceAccount:
     name: "cluster-autoscaler"

--- a/aws_example/tf-2-k8s/daytona.tf
+++ b/aws_example/tf-2-k8s/daytona.tf
@@ -3,7 +3,7 @@ resource "helm_release" "daytona_workspace" {
   namespace  = kubernetes_namespace.watkins.metadata[0].name
   repository = "oci://ghcr.io/daytonaio/charts"
   chart      = "watkins"
-  version    = "2.99.0"
+  version    = "2.100.1"
   timeout    = 720
   atomic     = true
 
@@ -15,15 +15,14 @@ namespaceOverride: "watkins"
 fullnameOverride: "watkins"
 configuration:
   defaultWorkspaceClass:
-    runtimeClassName: sysbox-runc
-    name: Default
     cpu: 2
+    gpu: ""
     memory: 8
+    name: Default
     storage: 50
     usageMultiplier: 1
-    # Leave undefined for disabled GPU support in default workspace class
-    gpu: ""
-  gpuResourceName: nvidia.com/gpu
+    runtimeClass: sysbox-runc
+    gpuResourceName: nvidia.com/gpu
   workspaceStorageClass: longhorn
   workspaceNamespace:
     name: watkins-workspaces
@@ -53,7 +52,19 @@ components:
         service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
   workspaceProvisioner:
     workspaces:
+      nodeSelector: '{"daytona.io/node-role" : "workload"}'
       tolerations: '[{"key": "daytona.io/node-role", "operator": "Equal", "value": "workload", "effect": "NoSchedule"}]'
+  workspaceVolumeInit:
+    storageInit:
+      nodeSelector: '{"daytona.io/node-role" : "workload"}'
+      tolerations: '[{"key": "daytona.io/node-role", "operator": "Equal", "value": "workload", "effect": "NoSchedule"}]'
+    nodeSelector:
+      daytona.io/node-role: "workload"
+    podTolerations:
+      - key: "daytona.io/node-role"
+        operator: "Equal"
+        value: "workload"
+        effect: "NoSchedule"
 gitProviders:
   github:
     clientId: ${local.github_client_id}

--- a/aws_example/tf-2-k8s/longhorn.tf
+++ b/aws_example/tf-2-k8s/longhorn.tf
@@ -4,23 +4,11 @@ resource "kubectl_manifest" "runtime_checker" {
   yaml_body = each.value
 }
 
-resource "kubectl_manifest" "longhorn_priority_class" {
-  yaml_body = <<YAML
-apiVersion: scheduling.k8s.io/v1
-kind: PriorityClass
-metadata:
-  name: custom-node-critical
-value: 1000000000
-globalDefault: false
-description: "Custom PriorityClass for longhorn pods"
-YAML
-}
-
 resource "helm_release" "longhorn" {
   name       = "longhorn"
   repository = "https://charts.longhorn.io"
   chart      = "longhorn"
-  version    = "1.5.3"
+  version    = "1.6.2"
   namespace  = kubernetes_namespace.longhorn-system.metadata[0].name
   timeout    = 300
   atomic     = false
@@ -45,10 +33,8 @@ defaultSettings:
   storageReservedPercentageForDefaultDisk: 15
   systemManagedComponentsNodeSelector: "daytona.io/runtime-ready:true"
   taintToleration: "daytona.io/node-role=storage:NoSchedule;daytona.io/node-role=workload:NoSchedule"
-  priorityClass: custom-node-critical
   guaranteedInstanceManagerCPU: 20
 longhornManager:
-  priorityClass: custom-node-critical
   nodeSelector:
     daytona.io/runtime-ready: "true"
   tolerations:
@@ -61,7 +47,6 @@ longhornManager:
       value: "workload"
       effect: "NoSchedule"
 longhornDriver:
-  priorityClass: custom-node-critical
   nodeSelector:
     daytona.io/runtime-ready: "true"
   tolerations:
@@ -77,7 +62,6 @@ longhornDriver:
   ]
 
   depends_on = [
-    kubectl_manifest.longhorn_priority_class,
     kubectl_manifest.sysbox,
     helm_release.aws_load_balancer_controller
   ]

--- a/aws_example/tf-2-k8s/outputs.tf
+++ b/aws_example/tf-2-k8s/outputs.tf
@@ -1,28 +1,21 @@
-output "cluster_name" {
-  description = "Kubernetes Cluster Name"
-  value       = local.cluster_name
-}
+output "daytona_access_instructions" {
+  value = <<EOT
+** Please be patient while the Daytona is being deployed, DNS records propagate and ingress is ready **
 
-output "daytona_url" {
-  description = "Daytona dashboard URL"
-  value       = "https://${local.dns_zone}"
-}
+1. Daytona can be accessed through the following DNS name:
 
-output "keycloak_url" {
-  description = "Keycloak URL"
-  value       = "https://id.${local.dns_zone}"
-}
+   https://${local.dns_zone}
 
-data "kubernetes_secret" "keycloak_admin" {
-  metadata {
-    name      = "watkins-watkins-keycloak"
-    namespace = kubernetes_namespace.watkins.metadata[0].name
-  }
+2. To access the Administration Console use the following:
 
-  depends_on = [helm_release.daytona_workspace]
-}
+   URL:       https://admin.${local.dns_zone}
+   Username:  admin
+   Password:  $(kubectl get secret --namespace ${kubernetes_namespace.watkins.metadata[0].name} ${helm_release.daytona_workspace.name} -o jsonpath={.data.admin-password} | base64 --decode; echo)
 
-output "keycloak_admin_password" {
-  description = "Keycloak user/password"
-  value       = "admin / ${nonsensitive(data.kubernetes_secret.keycloak_admin.data["admin-password"])}"
+3. To access Keycloak admin portal use the following:
+
+   URL:       https://id.${local.dns_zone}
+   Username:  admin
+   Password:  $(kubectl get secret --namespace ${kubernetes_namespace.watkins.metadata[0].name} ${helm_release.daytona_workspace.name}-watkins-keycloak -o jsonpath={.data.admin-password} | base64 --decode; echo)
+EOT
 }

--- a/aws_example/tf-2-k8s/sysbox.tf
+++ b/aws_example/tf-2-k8s/sysbox.tf
@@ -69,7 +69,7 @@ spec:
         effect: "NoSchedule"
       containers:
       - name: sysbox-deploy-k8s
-        image: registry.nestybox.com/nestybox/sysbox-deploy-k8s:v0.6.3
+        image: registry.nestybox.com/nestybox/sysbox-deploy-k8s:v0.6.4
         imagePullPolicy: Always
         command: [ "bash", "-c", "/opt/sysbox/scripts/sysbox-deploy-k8s.sh ce install" ]
         env:
@@ -175,9 +175,6 @@ kind: RuntimeClass
 metadata:
   name: sysbox-runc
 handler: sysbox-runc
-scheduling:
-  nodeSelector:
-    sysbox-runtime: running
 YAML
 
   depends_on = [kubectl_manifest.sysbox]


### PR DESCRIPTION
* allow separation of longhorn components only on workload and longhorn volume nodes
* update longhorn and sysbox release
* set k8s version to 1.29
* add TF output with access information to admin dashboard so licence can be added
* allow scale down of workload pool to 0 (this will require longer initial watkins install as the prepull of longhorn image will trigger scale up in order to finish)