### PR TITLE
fix(aws): atomic/job wait on daytona release

### DIFF
--- a/aws_example/tf-2-k8s/daytona.tf
+++ b/aws_example/tf-2-k8s/daytona.tf
@@ -5,8 +5,8 @@ resource "helm_release" "daytona_workspace" {
   chart         = "watkins"
   version       = "2.101.2"
   timeout       = 1800
-  atomic        = true
-  wait_for_jobs = true
+  atomic        = false
+  wait_for_jobs = false
 
   values = [<<YAML
 image:


### PR DESCRIPTION
* will find another way to wait for daytona volume-init job before marking tf plan complete